### PR TITLE
updated linux image source & some fixes for install_gnmic.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ clab-anysec-macsec/
 *.key
 *.log
 configs/webserver/__pycache__/
+configs/webserver/venv
 *.bak
 containerlab
+

--- a/anysec-macsec.clab.yml
+++ b/anysec-macsec.clab.yml
@@ -12,7 +12,7 @@ topology:
       image: registry.srlinux.dev/pub/vr-sros:23.10.R1
       license: /opt/nokia/sros/r23_license.key
     linux:
-      image: ghcr.io/hellt/network-multitool
+      image: ghcr.io/srl-labs/network-multitool
 
   nodes:
     ### CORE FP5 and FP4###

--- a/scripts/install_gnmic.sh
+++ b/scripts/install_gnmic.sh
@@ -19,8 +19,7 @@ echo "END Install Sw !"
 ### Start Flask and Python installation 
 echo "..."
 echo "Start Flask and Python installation script execution!"
-cd /
-mkdir flask_app && cd flask_app
+cd /flask_app
 python3 -m venv venv
 source venv/bin/activate
 export FLASK_APP=/flask_app/app.py
@@ -36,7 +35,7 @@ pip install -r /config/requirements.txt
 #python -m flask --version
 #apt-get install gunicorn
 #flask run &
-flask run --host=0.0.0.0 &
+HTTPS_PROXY= HTTP_PROXY= http_proxy= https_proxy= flask run --host=0.0.0.0 &
 sleep 5
 echo "END Flask and Python installation script execution!"
 


### PR DESCRIPTION
The PR add some fixes on install_gnmic.sh behavior:

- This errors were seen when using ghcr.io/hellt/network-multitool as image source. Not happening after changing to ghcr.io/srl-labs/network-multitool

```
bash-5.0# source venv/bin/activate
(venv) bash-5.0# export FLASK_APP=/flask_app/app.py
(venv) bash-5.0# pip install -r /config/requirements.txt
Collecting pygnmi
  Using cached pygnmi-0.8.13.tar.gz (31 kB)
Collecting flask
  Using cached flask-3.0.2-py3-none-any.whl (101 kB)
Collecting grpcio
  Using cached grpcio-1.62.0.tar.gz (26.3 MB)
    ERROR: Command errored out with exit status 1:
     command: /flask_app/venv/bin/python3 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-uo2izcuz/grpcio_5f3cc755f12d4b068d8773f0c50fa333/setup.py'"'"'; __file__='"'"'/tmp/pip-install-uo2izcuz/grpcio_5f3cc755f12d4b068d8773f0c50fa333/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-dycs7uft
         cwd: /tmp/pip-install-uo2izcuz/grpcio_5f3cc755f12d4b068d8773f0c50fa333/
    Complete output (11 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-uo2izcuz/grpcio_5f3cc755f12d4b068d8773f0c50fa333/setup.py", line 273, in <module>
        if check_linker_need_libatomic():
      File "/tmp/pip-install-uo2izcuz/grpcio_5f3cc755f12d4b068d8773f0c50fa333/setup.py", line 217, in check_linker_need_libatomic
        cpp_test = subprocess.Popen(
      File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
        self._execute_child(args, executable, preexec_fn, close_fds,
      File "/usr/lib/python3.8/subprocess.py", line 1704, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
    FileNotFoundError: [Errno 2] No such file or directory: 'c++'
    ----------------------------------------

```

- If proxy is set via environment vars, python grpc calls will use it, therefore failing to reach the nodes. I have attempted using no_proxy environment var, but didn't work. So let's make sure to unset proxy env vars when launching flask.