### PR TITLE
Use dependencies to wait for P/PE/CE nodes before starting the server

### DIFF
--- a/anysec-macsec.clab.yml
+++ b/anysec-macsec.clab.yml
@@ -65,8 +65,24 @@ topology:
         - scripts/requirements.txt:/config/requirements.txt
         - scripts/install_gnmic.sh:/config/install_gnmic.sh:rw
         - configs/webserver/:/flask_app/
-      exec:
-        - bash /config/setup-client7.sh
+      stages:
+        configure:
+          wait-for:
+            - node: pe1
+              stage: healthy
+            - node: pe2
+              stage: healthy
+            - node: p3
+              stage: healthy
+            - node: p4
+              stage: healthy
+            - node: ce5
+              stage: healthy
+            - node: ce6
+              stage: healthy
+          exec:
+            on-exit:
+              - bash /config/setup-client7.sh
       group: server
       ports:
         - 9080:80


### PR DESCRIPTION
@tiago-amado @mairp @alfilipe

this is a hotfix to make this lab compatible with clab 0.52+

I shared the details with @alfilipe, the culprit is that the web app doesn't handle network unreachable nodes when trying to fetch the port status with gnmi.

In this PR I used the stages dependency to ensure that the client7 node executes its setup in the `configure` stage after all routers are rendered healthy. This makes the ports reachable by the time the flask app starts.